### PR TITLE
Feature/implement queue receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,13 @@ The transport has a number of options:
 | entity_path            | Topic or Queue                   | name of transport         |
 | subscription           | Name of subscription             |                           |
 | wait_time              | Long polling duration in seconds |                           |
+
+You can change the `entity_path` runtime using the `AzureServiceBusEntityPathStamp`:
+```php
+$eventBus->dispatch($someMessage, [new AzureServiceBusEntityPathStamp('someEntityPath')]);
+```
+
+You can control the `entity_path` used on consume with:
+```
+php bin/console messenger:consume my_transport --queues=someEntityPath
+```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The transport has a number of options:
 | subscription           | Name of subscription             |                           |
 | wait_time              | Long polling duration in seconds |                           |
 
-You can change the `entity_path` runtime using the `AzureServiceBusEntityPathStamp`:
+You can change the `entity_path` at runtime using the `AzureServiceBusEntityPathStamp`:
 ```php
 $eventBus->dispatch($someMessage, [new AzureServiceBusEntityPathStamp('someEntityPath')]);
 ```

--- a/src/Azure/ServiceBus/BrokeredMessage.php
+++ b/src/Azure/ServiceBus/BrokeredMessage.php
@@ -3,6 +3,7 @@
 namespace HalloVerden\AzureServiceBusMessengerBundle\Azure\ServiceBus;
 
 class BrokeredMessage {
+  private ?string $entityPath = null;
 
   /**
    * BrokeredMessage constructor.
@@ -33,6 +34,23 @@ class BrokeredMessage {
    */
   public function getCustomProperties(): CustomProperties {
     return $this->customProperties;
+  }
+
+  /**
+   * @return string|null
+   */
+  public function getEntityPath(): ?string {
+    return $this->entityPath;
+  }
+
+  /**
+   * @param string|null $entityPath
+   *
+   * @return BrokeredMessage
+   */
+  public function setEntityPath(?string $entityPath): BrokeredMessage {
+    $this->entityPath = $entityPath;
+    return $this;
   }
 
 }

--- a/src/Transport/AzureServiceBusEntityPathStamp.php
+++ b/src/Transport/AzureServiceBusEntityPathStamp.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace HalloVerden\AzureServiceBusMessengerBundle\Transport;
+
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+
+class AzureServiceBusEntityPathStamp implements NonSendableStampInterface {
+  private string $entityPath;
+
+  /**
+   * AzureServiceBusEntityPathStamp constructor.
+   */
+  public function __construct(string $entityPath) {
+    $this->entityPath = $entityPath;
+  }
+
+  /**
+   * @return string
+   */
+  public function getEntityPath(): string {
+    return $this->entityPath;
+  }
+
+}

--- a/src/Transport/AzureServiceBusTransport.php
+++ b/src/Transport/AzureServiceBusTransport.php
@@ -3,14 +3,13 @@
 namespace HalloVerden\AzureServiceBusMessengerBundle\Transport;
 
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
-use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+use Symfony\Component\Messenger\Transport\Receiver\QueueReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 
-class AzureServiceBusTransport implements TransportInterface {
-  private ?ReceiverInterface $receiver = null;
-  private ?SenderInterface $sender = null;
+class AzureServiceBusTransport implements TransportInterface, QueueReceiverInterface {
+  private ?AzureServiceBusReceiver $receiver = null;
+  private ?AzureServiceBusSender $sender = null;
 
   /**
    * AzureServiceBusTransport constructor.
@@ -44,22 +43,30 @@ class AzureServiceBusTransport implements TransportInterface {
 
   /**
    * @inheritDoc
+   * @throws \Exception
    */
   public function send(Envelope $envelope): Envelope {
     return $this->getSender()->send($envelope);
   }
 
   /**
-   * @return ReceiverInterface
+   * @inheritDoc
    */
-  private function getReceiver(): ReceiverInterface {
+  public function getFromQueues(array $queueNames): iterable {
+    return $this->getReceiver()->getFromQueues($queueNames);
+  }
+
+  /**
+   * @return AzureServiceBusReceiver
+   */
+  private function getReceiver(): AzureServiceBusReceiver {
     return $this->receiver ??= new AzureServiceBusReceiver($this->connection, $this->serializer);
   }
 
   /**
-   * @return SenderInterface
+   * @return AzureServiceBusSender
    */
-  private function getSender(): SenderInterface {
+  private function getSender(): AzureServiceBusSender {
     return $this->sender ??= new AzureServiceBusSender($this->connection, $this->serializer);
   }
 


### PR DESCRIPTION
Implements QueueReceiverInterface. this enables the `--queues=<some queue>` option on the `messenger:consume` command.

As a result of this we no longer require the `entity_path` option, since this can be set on consume. Also it can be set on send using the `AzureServiceBusEntityPathStamp`