### PR TITLE
Include custom properties in envelope

### DIFF
--- a/src/Transport/AzureServiceBusReceiver.php
+++ b/src/Transport/AzureServiceBusReceiver.php
@@ -91,7 +91,8 @@ class AzureServiceBusReceiver implements ReceiverInterface, QueueReceiverInterfa
 
     $envelope = $this->serializer->decode([
       'body' => $brokerMessage->getBody(),
-      'headers' => $this->createHeaders($brokerMessage)
+      'headers' => $this->createHeaders($brokerMessage),
+      'customProperties' => iterator_to_array($brokerMessage->getCustomProperties())
     ]);
 
     yield $envelope


### PR DESCRIPTION
For convenience, include custom properties to envelope for easy access in the transport serializer decode method. 